### PR TITLE
fix: copilot link mode destroys symlinks during model replacement

### DIFF
--- a/.chief/project.md
+++ b/.chief/project.md
@@ -1,29 +1,50 @@
 # Project Configuration
 
-> Fill in the sections below with your project's specific details.
-> This file is referenced by the chief-agent framework for project context.
+## Overview
 
-## Development Commands
+This project **is** the Chief Agent Framework. The root-level `.agents/`, `.chief/`, and `AGENTS.md` are dogfooded — this project uses its own framework on itself.
 
-> Commands to run during development and testing.
-> Adjust as needed for your environment.
-
-## Architecture Overview
-
-> A brief overview of the architecture, key patterns, and important rules.
-
-### Tech Stack
-
-> List of major technologies used in the project.
-
-### Key Architectural Patterns
-
-> Description of important architectural patterns (e.g., Repository Pattern, Service Layer, etc.)
+## Architecture
 
 ### Directory Structure
 
-> The main directory structure of the project.
+```
+project/
+├── AGENTS.md              # Framework rules (dogfooded)
+├── CLAUDE.md → AGENTS.md  # Symlink for Claude Code
+├── .agents/               # Dogfooded agent definitions (no placeholders)
+├── .chief/                # Dogfooded planning state
+├── template/              # Installable package — what setup copies into user projects
+│   ├── .agents/           # Agent definitions with ${thinking_model}/${coding_model} placeholders
+│   ├── .chief/            # Blank project scaffold (empty project.md, _rules/, etc.)
+│   └── AGENTS.md          # Framework rules file
+├── scripts/
+│   └── setup.sh           # Installation script
+└── docs/                  # Additional documentation
+```
 
-### Important Development Rules
+### Key Distinction
 
-> Key rules that developers must follow.
+- `template/` = the package that gets installed into other projects
+- Root-level files = this project eating its own dogfood
+
+## Setup Concept
+
+Installation into a user project follows these steps (regardless of script or manual):
+
+1. Copy `template/.agents/` → target `.agents/`
+2. Copy `template/.chief/` → target `.chief/`
+3. Copy `template/AGENTS.md` → target `AGENTS.md`
+4. Replace `${thinking_model}` and `${coding_model}` placeholders in `.agents/agents/*.md` with actual model names
+5. Create agent-specific integration files (symlinks or copies from `.agents/agents/` to `.claude/agents/`, `.github/agents/`, etc.)
+
+### Critical Rule
+
+Always modify the canonical `.agents/agents/` files first (step 4), then create symlinks or copies (step 5). Never run text replacement on symlinked files — `sed` on a symlink destroys it and replaces it with a regular file.
+
+## Tech Stack
+
+- Shell (bash) for setup scripts
+- Markdown for all agent definitions, rules, and documentation
+- Symlinks for integration with coding agents
+- No runtime dependencies

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -327,24 +327,26 @@ case "$AGENT" in
 
   copilot)
     echo "Setting up GitHub Copilot integration..."
+
+    # Replace models in canonical source FIRST (before creating symlinks/copies)
+    prompt_and_replace_models "$TARGET_DIR" ".agents/agents"
+
+    # THEN create integration files
     mkdir -p "$TARGET_DIR/.github/agents"
 
     if [[ "$MODE" == "link" ]]; then
-      # Symlink individual agent files
+      # Symlink individual agent files (symlinks reflect already-replaced canonical files)
       for agent_file in "$TARGET_DIR/.agents/agents"/*.md; do
         filename="$(basename "$agent_file")"
         create_symlink "../../.agents/agents/$filename" "$TARGET_DIR/.github/agents/$filename" ".github/agents/$filename"
       done
     else
-      # Copy individual agent files
+      # Copy individual agent files (copies made from already-replaced canonical files)
       for agent_file in "$TARGET_DIR/.agents/agents"/*.md; do
         filename="$(basename "$agent_file")"
         copy_to_dest "$agent_file" "$TARGET_DIR/.github/agents/$filename" ".github/agents/$filename"
       done
     fi
-
-    # Prompt for model replacement
-    prompt_and_replace_models "$TARGET_DIR" ".github/agents"
     ;;
 
   *)


### PR DESCRIPTION
## Summary

- Fix copilot setup.sh branch: model placeholder replacement (`sed`) was running on symlinked files in `.github/agents/`, which destroys symlinks and replaces them with regular files
- Reorder copilot setup to replace models in canonical `.agents/agents/` first, then create symlinks — matching claude-code's pattern
- Fill in `.chief/project.md` with framework architecture and setup concept documentation

## Root Cause

`sed` on a symlink writes to a temp file then `mv`s it over the symlink, replacing it with a regular file. The copilot branch was:
1. Creating symlinks `.github/agents/` → `../../.agents/agents/`
2. Running `sed` model replacement on `.github/agents/` (destroying the symlinks)

## Fix

Reorder to:
1. Replace model placeholders in `.agents/agents/` (canonical source)
2. Then create symlinks/copies (which now reflect the already-replaced content)

## Test plan

- [x] Tested `install-chief main.fix-install-v2` with copilot + link mode
- [x] All 4 `.github/agents/` symlinks resolve correctly after install
- [x] Models configured correctly (claude-opus-4.6 / claude-sonnet-4.6)
- [x] All verification checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)